### PR TITLE
chore: ignore filter images and document external files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+filters/*.png

--- a/ar.html
+++ b/ar.html
@@ -173,6 +173,11 @@
       document.getElementById('status').textContent = message;
       debugLog(`STATUS: ${message}`);
     }
+      const FILTERS = [
+        'filters/crown.png',
+        'filters/glasses.png',
+        'filters/mustache.png'
+      ]; // 실제 이미지 파일은 별도로 추가
 
     class SimpleARFilter {
       constructor() {


### PR DESCRIPTION
## Summary
- ignore filter PNG images so binaries are not committed
- note in `FILTERS` constant that real image files should be added separately

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68afaf436f408331ab1bb259ee80176f