### PR TITLE
Randomize initial AR filter

### DIFF
--- a/ar.html
+++ b/ar.html
@@ -229,7 +229,6 @@
         this.renderer = null;
         this.filterGroup = null;
         this.isRunning = false;
-        this.currentFilter = 0;
         this.facingMode = 'user';
         this.faceMesh = null;
         this.cameraUtils = null;
@@ -238,6 +237,7 @@
       }
 
       async init() {
+        this.currentFilter = Math.floor(Math.random() * FILTERS.length);
         try {
           debugLog('초기화 시작');
           


### PR DESCRIPTION
## Summary
- Randomize initial filter selection during AR initialization
- Remove default filter index from constructor

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68afc8aa06e08331bd63e371ed28351e