### PR TITLE
비동기 stop 처리 및 카메라 전환 대기

### DIFF
--- a/ar.html
+++ b/ar.html
@@ -494,9 +494,9 @@ onFaceResults(results) {
         }
       }
 
-      stop() {
+      async stop() {
         this.isRunning = false;
-        if (this.cameraUtils) this.cameraUtils.stop();
+        if (this.cameraUtils) await this.cameraUtils.stop();
         if (this.video && this.video.srcObject) {
           this.video.srcObject.getTracks().forEach(t => t.stop());
           this.video.remove();
@@ -505,6 +505,7 @@ onFaceResults(results) {
         if (this.renderer && this.renderer.domElement) {
           this.renderer.domElement.remove();
         }
+        return Promise.resolve();
       }
     }
 
@@ -622,7 +623,7 @@ filterPopup.addEventListener('click', (e) => {
         arApp.facingMode = (arApp.facingMode === 'user') ? 'environment' : 'user';
 
         try {
-          arApp.stop();
+          await arApp.stop();
           await arApp.init();
           const currentModeKor = arApp.facingMode === 'user' ? '전면' : '후면';
           const nextModeKor = arApp.facingMode === 'user' ? '후면' : '전면';
@@ -636,7 +637,7 @@ filterPopup.addEventListener('click', (e) => {
           // 이전 모드로 복구
           arApp.facingMode = prevMode;
           try {
-            arApp.stop();
+            await arApp.stop();
             await arApp.init();
             const nextModeKor = arApp.facingMode === 'user' ? '후면' : '전면';
             switchBtn.textContent = `카메라 전환 (${nextModeKor})`;


### PR DESCRIPTION
## 요약
- SimpleARFilter.stop을 async 함수로 변경하여 cameraUtils 중지와 트랙 해제 후 Promise 반환
- switch-camera 이벤트에서 arApp.stop을 await로 호출하도록 수정

## 테스트
- `npm test` (package.json 없음으로 실행 실패)


------
https://chatgpt.com/codex/tasks/task_e_68b00d89aed08331be3eaec06bee5f75